### PR TITLE
Create Virtual Serial Simulation

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -28,7 +28,7 @@ jobs:
         python -m unittest discover -v
     - name: Generate coverage report
       run: |
-        coverage run --source=gym_solo -m unittest discover
+        coverage run --source=ros2sim -m unittest discover
         coverage report
     - name: Coveralls
       env:

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,0 +1,37 @@
+# Run tests and send coverage report
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade wheel pip
+        python -m pip install coverage coveralls
+        python -m pip install -e .
+    - name: Run tests
+      run: |
+        python -m unittest discover -v
+    - name: Generate coverage report
+      run: |
+        coverage run --source=gym_solo -m unittest discover
+        coverage report
+    - name: Coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+      run: |
+        coveralls --service=github

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install --upgrade wheel pip
         python -m pip install coverage coveralls
-        python -m pip install -e .
+        python -m pip install -e .[test]
     - name: Run tests
       run: |
         python -m unittest discover -v

--- a/ros2sim/parsers/__init__.py
+++ b/ros2sim/parsers/__init__.py
@@ -1,1 +1,11 @@
+import enum
+
+class special(enum.Enum):
+  EOM = b'\r\n'
+  ACTION = b'ACTION'
+  RESET = b'RESET'
+  OBS_REQUEST = b'OBS'
+  OK = b'OK'
+
+
 from .base_parser import Parser

--- a/ros2sim/parsers/__init__.py
+++ b/ros2sim/parsers/__init__.py
@@ -9,3 +9,4 @@ class special(enum.Enum):
 
 
 from .base_parser import Parser
+from.json_parser import JsonParser

--- a/ros2sim/parsers/__init__.py
+++ b/ros2sim/parsers/__init__.py
@@ -1,0 +1,1 @@
+from .base_parser import Parser

--- a/ros2sim/parsers/base_parser.py
+++ b/ros2sim/parsers/base_parser.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Text
 
-import gym
-
 
 class Parser(ABC):
   """A generic parser class."""

--- a/ros2sim/parsers/base_parser.py
+++ b/ros2sim/parsers/base_parser.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+from typing import Text
+
+import gym
+
+
+class Parser(ABC):
+  """A generic parser class."""
+  def __init__(self, env):
+    self.env = env
+
+  @abstractmethod
+  def parse(input_str: Text) -> Text:
+    """React to an input string passed from the master device.
+
+    As most robot communications are in the master-slave design pattern, this
+    function will most likely just be a state machine that reacts to the 
+    master node.
+
+    Args:
+      input_str (Text): Encoded string from master to decode.
+
+    Returns:
+      Text: A response (if needed--else can return an empty string)
+    """
+    pass

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -1,4 +1,7 @@
+from typing import Text
+
 from ros2sim import parsers
+import json
 
 
 class JsonParser(parsers.Parser):
@@ -27,8 +30,15 @@ class JsonParser(parsers.Parser):
     """Reset the environment."""
     self.env.reset()
 
-  def get_obs(self, _):
-    pass
+  def get_obs(self, _) -> Text:
+    """Get the current observation of the robot.
+
+    Returns:
+      str: A JSON-encoded string of a dictionary of the registered observation
+        and the respective values.
+    """
+    labels, values = self.env.get_obs()
+    return json.dumps(dict(zip(labels, values)))
 
   def action(self, _):
     pass

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -1,0 +1,35 @@
+from ros2sim import parsers
+
+import json
+
+
+class JsonParser(parsers.Parser):
+  def __init__(self, env):
+    super().__init__(env)
+
+    # TODO: Talk to @andrew_103 about how exactly the parsing and deparsing
+    # work for embedded systems. Need to evaluate if this state machine logic
+    # can be abstracted abstracted out to the parent class.
+    self._COMMAND_MAPPING = {
+      parsers.special.RESET: self.reset,
+      parsers.special.OBS_REQUEST: self.get_obs,
+      parsers.special.ACTION: self.action,
+    }
+
+  def parse(self, input_str: str) -> str:
+    for cmd, func in self._COMMAND_MAPPING.items():
+      if input_str.startswith(cmd):
+        resp = func(cmd)
+        break
+
+    resp = resp or parsers.special.OK
+    return resp
+
+  def reset(self):
+    pass
+
+  def get_obs(self):
+    pass
+
+  def action(self):
+    pass

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -1,15 +1,13 @@
 from ros2sim import parsers
 
-import json
-
 
 class JsonParser(parsers.Parser):
   def __init__(self, env):
     super().__init__(env)
 
     # TODO: Talk to @andrew_103 about how exactly the parsing and deparsing
-    # work for embedded systems. Need to evaluate if this state machine logic
-    # can be abstracted abstracted out to the parent class.
+    # works for embedded systems. Need to evaluate if this state machine logic
+    # can be abstracted out to the parent class.
     self._COMMAND_MAPPING = {
       parsers.special.RESET: self.reset,
       parsers.special.OBS_REQUEST: self.get_obs,
@@ -18,18 +16,18 @@ class JsonParser(parsers.Parser):
 
   def parse(self, input_str: str) -> str:
     for cmd, func in self._COMMAND_MAPPING.items():
-      if input_str.startswith(cmd):
-        resp = func(cmd)
+      if input_str.startswith(cmd.value):
+        resp = func(input_str[len(cmd.value):])
         break
 
-    resp = resp or parsers.special.OK
+    resp = resp or parsers.special.OK.value
     return resp
 
-  def reset(self):
+  def reset(self, _):
     pass
 
-  def get_obs(self):
+  def get_obs(self, _):
     pass
 
-  def action(self):
+  def action(self, _):
     pass

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -18,6 +18,7 @@ class JsonParser(parsers.Parser):
     }
 
   def parse(self, input_str: str) -> str:
+    resp =  None
     for cmd, func in self._COMMAND_MAPPING.items():
       if input_str.startswith(cmd.value):
         resp = func(input_str[len(cmd.value):])

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -40,5 +40,19 @@ class JsonParser(parsers.Parser):
     labels, values = self.env.get_obs()
     return json.dumps(dict(zip(labels, values)))
 
-  def action(self, _):
-    pass
+  def action(self, cmd):
+    """Apply the action to the robot.
+
+    Note that in this case, these values will usually be motor position values.
+
+    Args:
+      cmd ([str]): JSON encoded dictionary of motor values
+    """
+    action_dict = json.loads(cmd)
+    action = [action_dict[joint] for joint in self.env.joint_ordering]
+    
+    if len(action) != len(self.env.joint_ordering):
+      raise ValueError('The action needs to have the same number of joint as '
+                       'the robot')
+
+    self.env.step(action)

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -54,6 +54,7 @@ class JsonParser(parsers.Parser):
       action = [action_dict[joint] for joint in self.env.joint_ordering]
       if len(action) != len(self.env.joint_ordering):
         raise
+
       self.env.step(action)
     except:
       raise ValueError('The action needs to have the same number of joint as '

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -18,14 +18,13 @@ class JsonParser(parsers.Parser):
     }
 
   def parse(self, input_str: str) -> str:
-    resp =  None
+    resp = None
     for cmd, func in self._COMMAND_MAPPING.items():
       if input_str.startswith(cmd.value):
         resp = func(input_str[len(cmd.value):])
         break
 
-    resp = resp or parsers.special.OK.value
-    return resp
+    return resp.encode() if resp else parsers.special.OK.value
 
   def reset(self, _):
     """Reset the environment."""
@@ -38,7 +37,7 @@ class JsonParser(parsers.Parser):
       str: A JSON-encoded string of a dictionary of the registered observation
         and the respective values.
     """
-    labels, values = self.env.get_obs()
+    values, labels = self.env.get_obs()
     return json.dumps(dict(zip(labels, values)))
 
   def action(self, cmd):

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -49,10 +49,12 @@ class JsonParser(parsers.Parser):
       cmd ([str]): JSON encoded dictionary of motor values
     """
     action_dict = json.loads(cmd)
-    action = [action_dict[joint] for joint in self.env.joint_ordering]
-    
-    if len(action) != len(self.env.joint_ordering):
+
+    try:
+      action = [action_dict[joint] for joint in self.env.joint_ordering]
+      if len(action) != len(self.env.joint_ordering):
+        raise
+      self.env.step(action)
+    except:
       raise ValueError('The action needs to have the same number of joint as '
                        'the robot')
-
-    self.env.step(action)

--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -24,7 +24,8 @@ class JsonParser(parsers.Parser):
     return resp
 
   def reset(self, _):
-    pass
+    """Reset the environment."""
+    self.env.reset()
 
   def get_obs(self, _):
     pass

--- a/ros2sim/parsers/test_base_parser.py
+++ b/ros2sim/parsers/test_base_parser.py
@@ -8,7 +8,6 @@ class DummyParser(Parser):
     pass
 
 
-
 class TestBasicParser(unittest.TestCase):
   def test_construction(self):
     env = 'test'

--- a/ros2sim/parsers/test_base_parser.py
+++ b/ros2sim/parsers/test_base_parser.py
@@ -1,0 +1,19 @@
+import unittest
+
+from ros2sim.parsers import Parser
+
+
+class DummyParser(Parser):
+  def parse(input_str):
+    pass
+
+
+
+class TestBasicParser(unittest.TestCase):
+  def test_construction(self):
+    env = 'test'
+    parser = DummyParser(env)
+    self.assertEqual(env, parser.env)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -1,0 +1,35 @@
+from ros2sim.parsers import json_parser
+from ros2sim.parsers import special as s
+
+
+from parameterized import parameterized
+from unittest import mock
+
+import unittest
+
+
+class TestJsonParser(unittest.TestCase):
+  def setUp(self):
+    self.env_stub = mock.MagicMock()
+    self.parser = json_parser.JsonParser(self.env_stub)
+
+  @parameterized.expand([
+    ('reset_empty', 'reset', s.RESET.value, b''),
+    ('reset_extra', 'reset', s.RESET.value + b'test', b'test'),
+    ('action_empty', 'action', s.ACTION.value, b''),
+    ('action_extra', 'action', s.ACTION.value + b'test', b'test'),
+    ('get_obs_empty', 'get_obs', s.OBS_REQUEST.value, b''),
+    ('get_obs_extra', 'get_obs', s.OBS_REQUEST.value + b'test', b'test'),
+  ])
+  def test_parsing(self, name, funcname, cmd, input_str):
+    with mock.patch.object(json_parser.JsonParser, funcname,
+                           return_value=None) as mock_method:
+      parser = json_parser.JsonParser(self.env_stub)
+      resp = parser.parse(cmd)
+
+      mock_method.assert_called_once_with(input_str)
+      self.assertEqual(resp, s.OK.value)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -58,5 +58,15 @@ class TestJsonParser(unittest.TestCase):
     self.env_stub.get_obs.assert_called_once()
     self.assertEqual(resp, encoded_str)
 
+  @parameterized.expand([
+    ('simple', {'j1': 1., 'j2': 2., 'j3': 3.,}, [1., 2., 3]), 
+    ('extra', {'j1': 1., 'j2': 2., 'j3': 3., 'j4': 4.,}, [1., 2., 3]), 
+  ])
+  def test_action(self, name, sent_actions, expected_input):
+    self.env_stub.joint_ordering = ['j1', 'j2', 'j3']
+    self.parser.action(json.dumps(sent_actions))
+    self.env_stub.step.assert_called_once_with(expected_input)
+    
+
 if __name__ == '__main__':
   unittest.main()

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -66,6 +66,12 @@ class TestJsonParser(unittest.TestCase):
     self.env_stub.joint_ordering = ['j1', 'j2', 'j3']
     self.parser.action(json.dumps(sent_actions))
     self.env_stub.step.assert_called_once_with(expected_input)
+
+  def test_too_few_actions(self):
+    self.env_stub.joint_ordering = ['j1', 'j2', 'j3']
+    action = {'j1': 1., 'j2': 2.,}
+    with self.assertRaises(ValueError):
+      self.parser.action(json.dumps(action))
     
 
 if __name__ == '__main__':

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -1,9 +1,9 @@
 from ros2sim.parsers import json_parser
 from ros2sim.parsers import special as s
 
-
 from parameterized import parameterized
 from unittest import mock
+import json
 
 import unittest
 
@@ -37,6 +37,26 @@ class TestJsonParser(unittest.TestCase):
   def test_reset(self, name, cmd):
     self.parser.reset(cmd)
     self.env_stub.reset.assert_called_once()
+
+  @parameterized.expand([
+    ('simple', b''),
+    ('extra_stuff', b'extra_stuff'),
+  ])
+  def test_get_obs(self, name, cmd):
+    dummy_obs = ['lbl1', 'lbl2', 'lbl3'], [1., 2., 3.] 
+    self.env_stub.get_obs.return_value = dummy_obs
+
+    encoded_obs = {
+      'lbl1': 1.,
+      'lbl2': 2.,
+      'lbl3': 3.,
+    }
+    encoded_str = json.dumps(encoded_obs)
+
+    resp = self.parser.get_obs(cmd)
+
+    self.env_stub.get_obs.assert_called_once()
+    self.assertEqual(resp, encoded_str)
 
 if __name__ == '__main__':
   unittest.main()

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -43,7 +43,7 @@ class TestJsonParser(unittest.TestCase):
     ('extra_stuff', b'extra_stuff'),
   ])
   def test_get_obs(self, name, cmd):
-    dummy_obs = ['lbl1', 'lbl2', 'lbl3'], [1., 2., 3.] 
+    dummy_obs = [1., 2., 3.], ['lbl1', 'lbl2', 'lbl3']
     self.env_stub.get_obs.return_value = dummy_obs
 
     encoded_obs = {

--- a/ros2sim/parsers/test_json_parser.py
+++ b/ros2sim/parsers/test_json_parser.py
@@ -30,6 +30,13 @@ class TestJsonParser(unittest.TestCase):
       mock_method.assert_called_once_with(input_str)
       self.assertEqual(resp, s.OK.value)
 
+  @parameterized.expand([
+    ('simple', b''),
+    ('extra_stuff', b'extra_stuff'),
+  ])
+  def test_reset(self, name, cmd):
+    self.parser.reset(cmd)
+    self.env_stub.reset.assert_called_once()
 
 if __name__ == '__main__':
   unittest.main()

--- a/ros2sim/sims/__init__.py
+++ b/ros2sim/sims/__init__.py
@@ -1,0 +1,1 @@
+from .serial import SerialSimulator

--- a/ros2sim/sims/serial.py
+++ b/ros2sim/sims/serial.py
@@ -27,6 +27,7 @@ class SerialSimulator:
     Realtime Simulation now active.
     Serving on {}
     """.format(s_name))
+    thread.join()
 
   def listener(self):
     while True:

--- a/ros2sim/sims/serial.py
+++ b/ros2sim/sims/serial.py
@@ -1,11 +1,38 @@
+import pty
+import os
+import serial
+import threading
+
 from ros2sim.parsers import Parser
+from ros2sim.parsers import special as s
 
 
 class SerialSimulator:
-  def __init__(self, parser: Parser):
+  def __init__(self, parser: Parser, baudrate=9600):
     """Create a new Serial simulator
 
     Args:
       parser (Parser): Which parser to use
     """
     self.parser = parser
+
+  def serve(self):
+    self.master, slave = pty.openpty()
+    s_name = os.ttyname(slave)
+
+    thread = threading.Thread(target=self.listener)
+    thread.start()
+
+    print("""
+    Realtime Simulation now active.
+    Serving on {}
+    """.format(s_name))
+
+  def listener(self):
+    while True:
+      request = b''
+      while not request.endswith(s.EOM.value):
+        request += os.read(self.master, 1)
+
+      response = self.parser.parse(request)
+      os.write(self.master, response + s.EOM.value)

--- a/ros2sim/sims/serial.py
+++ b/ros2sim/sims/serial.py
@@ -1,0 +1,11 @@
+from ros2sim.parsers import Parser
+
+
+class SerialSimulator:
+  def __init__(self, parser: Parser):
+    """Create a new Serial simulator
+
+    Args:
+      parser (Parser): Which parser to use
+    """
+    self.parser = parser

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,1 @@
+# Solo Simulators

--- a/scripts/interactive.py
+++ b/scripts/interactive.py
@@ -1,0 +1,21 @@
+from ros2sim.parsers import special as s
+import serial
+
+
+if __name__ == '__main__':
+  port = input('Enter the port to bind to: ')
+  ser = serial.Serial(port, 9600, timeout=1)
+
+  try:
+    while True:
+      cmd = input('Send the following command: ')
+      ser.write(cmd.encode() + s.EOM.value)
+
+      res = b''
+      while not res.endswith(s.EOM.value):
+        res += ser.read()
+      
+      print('Response: {}'.format(res))
+
+  except KeyboardInterrupt:
+    pass

--- a/scripts/solo8v2vanilla_serial.py
+++ b/scripts/solo8v2vanilla_serial.py
@@ -1,0 +1,18 @@
+from ros2sim import parsers
+from ros2sim import sims
+
+import gym
+import gym_solo
+
+from gym_solo.core import obs
+
+
+if __name__ == '__main__':
+  env = gym.make('solo8vanilla-realtime-v0')
+
+  env.obs_factory.register_observation(obs.TorsoIMU(env.robot))
+  env.obs_factory.register_observation(obs.MotorEncoder(env.robot))
+
+  parser = parsers.JsonParser(env)
+  simulator = sims.SerialSimulator(parser)
+  simulator.serve()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+
+setup(name='ros2sim',
+      version='0.0.1',
+      install_requires=[],
+      extras_require={
+        'test': []
+      }
+)

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup
 
 setup(name='ros2sim',
       version='0.0.1',
-      install_requires=[],
+      install_requires=['pyserial'],
       extras_require={
-        'test': []
+        'test': ['parameterized']
       }
 )


### PR DESCRIPTION
Create a realtime solo environment and be able to communicate with it over Serial. Note that this requires that https://github.com/WPI-MMR/gym_solo/pull/44 is merged in.

To get it working, there are two convenience scripts to get ya going (in the `scripts` folder). Run the `solo8...py` script first, which should open the PyBullet GUI and tell you which serial port to listen on. Then run `interactive.py` and attach to that aforementioned serial port. 

You can then type in the following commands:
- `RESET`
- `OBS`

`ACTION` is also implemented, but you need to pass an encoded JSON string, which is too much effort imo.