### PR TITLE
Enable CI for Python 3.6 + README Updates

### DIFF
--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,7 +1,7 @@
 # Run tests and send coverage report
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build
+name: Run Tests & Generate Coverage Report
 
 on: [push, pull_request]
 

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,7 +1,7 @@
 # Run tests and send coverage report
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Tests
+name: tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -1,7 +1,7 @@
 # Run tests and send coverage report
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Run Tests & Generate Coverage Report
+name: Tests
 
 on: [push, pull_request]
 

--- a/.github/workflows/python-test-coverage.yml
+++ b/.github/workflows/python-test-coverage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
   ros2sim<br/>
   <img src="https://upload.wikimedia.org/wikipedia/en/1/1b/WPI_logo.png" 
     alt="WPI Logo" width=75px/> <br />
-  <img src="https://github.com/WPI-MMR/ros2sim/workflows/Tests/badge.svg" 
+  <img src="https://github.com/WPI-MMR/ros2sim/workflows/tests/badge.svg" 
     alt="Build Status" />
+  <a href='https://coveralls.io/github/WPI-MMR/ros2sim?branch=master'>
+  <img src='https://coveralls.io/repos/github/WPI-MMR/ros2sim/badge.svg?branch=master' alt='Coverage Status' /></a>
+
 </h1>
 
 <p align='center'><i>A virtual serial device to simulate the Solo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# ros2sim
-A virtual serial device to simulate the Solo
+<h1 align='center'> 
+  ros2sim<br/>
+  <img src="https://upload.wikimedia.org/wikipedia/en/1/1b/WPI_logo.png" 
+    alt="WPI Logo" width=75px/> <br />
+  <img src="https://github.com/WPI-MMR/ros2sim/workflows/Tests/badge.svg" 
+    alt="Build Status" />
+</h1>
+
+<p align='center'><i>A virtual serial device to simulate the Solo
+  </i></p>
+
+---


### PR DESCRIPTION
Since ROS2 is dependent upon python3.6, want to ensure that this repo is usable by that as well. Enable the github test runner to also run tests under python3.6 so that we know that this can be imported.

Note that the actual simulation functionality will be disabled because *gym_solo* requires Python >= 3.7. However, since ROS shouldn't ever actually touch the simulation (it is purely interacting over serial) and is only using the shared messages, there should be no problems using `ros2sim` with python3.6.