### PR TITLE
Add ros2sim package to setup.py

### DIFF
--- a/ros2sim/parsers/json_parser.py
+++ b/ros2sim/parsers/json_parser.py
@@ -53,7 +53,7 @@ class JsonParser(parsers.Parser):
     try:
       action = [action_dict[joint] for joint in self.env.joint_ordering]
       if len(action) != len(self.env.joint_ordering):
-        raise
+        raise ValueError
 
       self.env.step(action)
     except:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 setup(name='ros2sim',
       version='0.0.1',
+      packages=find_packages(),
       install_requires=['pyserial'],
       extras_require={
         'test': ['parameterized']


### PR DESCRIPTION
The setup.py doesn't actually have the packages declared. Declaring the packages makes it so that pip actually installs them :p